### PR TITLE
Ajax method renamed to be used in a display context as they should

### DIFF
--- a/controllers/admin/AdminPsMboModuleController.php
+++ b/controllers/admin/AdminPsMboModuleController.php
@@ -141,7 +141,7 @@ class AdminPsMboModuleController extends ModuleAdminController
         return json_encode($results);
     }
 
-    public function ajaxProcessGetModulesList()
+    public function displayAjaxGetModulesList()
     {
         $filters = new AddonListFilter();
         $filters->setType(AddonListFilterType::MODULE | AddonListFilterType::SERVICE)
@@ -216,7 +216,7 @@ class AdminPsMboModuleController extends ModuleAdminController
         return $presentedProducts;
     }
 
-    public function ajaxProcessGetModuleQuickView()
+    public function displayAjaxGetModuleQuickView()
     {
         $modules = Module::getModulesOnDisk();
 
@@ -250,7 +250,7 @@ class AdminPsMboModuleController extends ModuleAdminController
         $this->ajaxRender($this->context->smarty->fetch($this->module->template_dir . '/quickview.tpl'));
     }
 
-    public function ajaxProcessGetTabModulesList()
+    public function displayAjaxGetTabModulesList()
     {
         $result = $this->module->fetchModulesByController(true);
 
@@ -266,7 +266,7 @@ class AdminPsMboModuleController extends ModuleAdminController
         $this->smartyOutputContent($this->module->template_dir . '/include/admin-end-content-footer-legacy.tpl');
     }
 
-    public function ajaxProcessFetchModules()
+    public function displayAjaxFetchModules()
     {
         $this->ajaxRender($this->module->fetchModules(Tools::getValue('controller_page')));
     }
@@ -316,7 +316,7 @@ class AdminPsMboModuleController extends ModuleAdminController
         return $modules_list;
     }
 
-    public function ajaxProcessGetMboAddonsThemes()
+    public function displayAjaxGetMboAddonsThemes()
     {
         $parent_domain = Tools::getHttpHost(true) . substr($_SERVER['REQUEST_URI'], 0, -1 * strlen(basename($_SERVER['REQUEST_URI'])));
         $iso_lang = Context::getContext()->language->iso_code;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | master
| Description?  | An error was displayed in the "Themes & Logo" page, the problem was that every ajax calls in `AdminPsMboModuleController` were rendered with `ajaxProcess*` methods This resulted in updating the view before the initial header was sent causing many cascade problems afterwards (any use to Router, or access to the session resulted in an error). Since these ajax methods were used to display the page, the appropriate prefix is `displayAjax` so that they are rendered at the right time during the workflow
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/11461
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/11089)
<!-- Reviewable:end -->
